### PR TITLE
Add portainer and update variable datadog

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -2,7 +2,8 @@
 AGENT_VERSION=7.38.2
 
 # Datadog Keys
-DD_API_KEY=
+DD_API_KEY=c52f9b8dd084ada710c16sssssssss
+DD_SITE=us5.datadoghq.com
 
 # Postgres credentials
 PG_USER=pguser

--- a/docker-compose/docker-compose-broken-stack.yml
+++ b/docker-compose/docker-compose-broken-stack.yml
@@ -11,8 +11,9 @@ services:
       - DD_PROCESS_AGENT_ENABLED=true
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"devops bootcamp"}
       - DD_TAGS=${TAG_DEFAULTS}
+      - DD_SITE=${DD_SITE}
     ports:
-      - "8126:8126"
+      - "8126:8126/tcp"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro

--- a/docker-compose/docker-compose-stack.yml
+++ b/docker-compose/docker-compose-stack.yml
@@ -1,8 +1,9 @@
 version: '3'
 services:
   agent:
-    image: "datadog/agent:${AGENT_VERSION}"
-    hostname: "datadog-agent"
+    image: datadog/agent:${AGENT_VERSION}
+    # image: "datadog/agent:latest"
+    hostname: datadog-agent
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_APM_ENABLED=true
@@ -12,8 +13,9 @@ services:
       - DD_ENV=development
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"devops bootcamp"}
       - DD_TAGS=${TAG_DEFAULTS}
+      - DD_SITE=${DD_SITE}
     ports:
-      - "8126:8126"
+      - 8126:8126/tcp
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro

--- a/portainer/docker-compose.yaml
+++ b/portainer/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  portainer:
+    image: "portainer/portainer-ce:2.9.3"
+    hostname: "portainer"
+    ports:
+      - "9443:9443"
+      - "9000:9000"
+    volumes:
+      - portainer_data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: on-failure
+volumes:
+  portainer_data:
+    driver: local
+
+# sudo docker volume create portainer_data
+# sudo docker run -d \
+# -p 9000:9000 \
+# -p 9443:9443 \
+# --name portainer \
+# --restart=on-failure \
+# -v portainer_data:/data \
+# -v "/var/run/docker.sock:/var/run/docker.sock"  \
+# portainer/portainer-ce:2.9.3


### PR DESCRIPTION
Opa Flavio, como está, blz...

Desculpe a intromissão mas pode ser que alguém tenha passado pelo mesmo problema...

ao subir a stack tive alguns erros relacionados ao agent do datadog que reclamava 403... ao analisar a documentação encontrei a necessidade de colocar a variável DD_SITE=us5.datadoghq.com ... após esta alteração tanto no docker-compose.yml quanto no .env, o agente subiu liso...então tomei a liberdade de alterar aki e enviar pra voce analisar se deve atualizar no repo com estas informações... 

Obrigado a voce e a Wania pelo tempo disposto em trazer este assunto tão importante..